### PR TITLE
Update storage syntax

### DIFF
--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "elrond-wasm-sc-dns"
 version = "1.1.0"
-edition = "2018"
+edition = "2021"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
 license = "GPL-3.0-only"

--- a/dns/fuzz/Cargo.toml
+++ b/dns/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "dns-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/dns/meta/Cargo.toml
+++ b/dns/meta/Cargo.toml
@@ -2,7 +2,7 @@
 name = "elrond-wasm-sc-dns-abi"
 version = "0.0.0"
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies.elrond-wasm-sc-dns]

--- a/dns/tests/name_validation_test.rs
+++ b/dns/tests/name_validation_test.rs
@@ -22,14 +22,14 @@ fn test_validate_name() {
     assert!(validate_name("aa.elrond").is_err());
 
     // lowercase only
-    assert!(!validate_name("Aaaaaaaaaa.elrond").is_ok());
+    assert!(validate_name("Aaaaaaaaaa.elrond").is_err());
 
     // no other chars
-    assert!(validate_name("Aaaaa.aaaa.elrond").is_err());
-    assert!(validate_name("Aaaaa@aaaa.elrond").is_err());
-    assert!(validate_name("Aaaaa+aaaa.elrond").is_err());
-    assert!(validate_name("Aaaaa-aaaa.elrond").is_err());
-    assert!(validate_name("Aaaaa_aaaa.elrond").is_err());
+    assert!(validate_name("aaaaa.aaaa.elrond").is_err());
+    assert!(validate_name("aaaaa@aaaa.elrond").is_err());
+    assert!(validate_name("aaaaa+aaaa.elrond").is_err());
+    assert!(validate_name("aaaaa-aaaa.elrond").is_err());
+    assert!(validate_name("aaaaa_aaaa.elrond").is_err());
 
     // without suffix
     assert!(validate_name("aaaaaaaaaa").is_err());

--- a/dns/wasm/Cargo.toml
+++ b/dns/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "elrond-wasm-sc-dns-wasm"
 version = "0.0.0"
 authors = ["andrei-marinica <andrei_m_marinica@yahoo.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tools/name-miner/Cargo.toml
+++ b/tools/name-miner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-gen"
 version = "0.0.0"
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 sha3 = "0.9.1"

--- a/tools/name-miner/src/main.rs
+++ b/tools/name-miner/src/main.rs
@@ -20,10 +20,10 @@ fn main() {
     assert!(desired_shard.len() == 1, "shard id should be 1 byte");
 
     for i in 0..5000 {
-        let name = format!("{}{:04}.elrond", prefix, i);
+        let name = format!("{prefix}{i:04}.elrond");
         let hash = keccak256(name.as_bytes());
         if hash[31] == desired_shard[0] {
-            println!("{}", name);
+            println!("{name}");
         }
     }
 }


### PR DESCRIPTION
- use `SingleValueMapper` for `registration_cost` and `value_state` instead of `storage_get` and `storage_set`
- re-use values where applicable, either through calling `update`  or by re-using the storage mapper variable
- remove unused clippy allow flags
- fix clippy warnings
- changed existing tests for other chars as to not miss any testing scenarios